### PR TITLE
Support face colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 It is an add-on for Blender to import and export .bim files. Check out dotbim.net or main repo for dotbim (https://github.com/paireks/dotbim) to read more about .bim files :)
 
-Blender version > 3.6 is required.
+Blender version >= 3.6 is required.
 
 ## How to run a script
 
-1. First you need to install dotbimpy (https://github.com/paireks/dotbimpy) for Blender's Python. Check where it's packages (folder "site-packages) is located (e.g. for me it was C:\Program Files\Blender Foundation\Blender 2.91\2.91\python\lib\site-packages). Once you've found it, you need to install dotbimpy there. It can be done e.g. by:
+1. First you need to install dotbimpy (https://github.com/paireks/dotbimpy) for Blender's Python. Check where it's packages (folder "site-packages) is located (e.g. for me it was C:\Program Files\Blender Foundation\Blender 3.6\3.6\python\lib\site-packages). Once you've found it, you need to install dotbimpy there. It can be done e.g. by:
 ```cmd
 pip install --target="your\path" dotbimpy
 ```
-Additional note: sometimes it requires to open cmd with admin rights (if there is no permission to access to that directory).
+**Additional note**: sometimes it requires to open cmd with admin rights (if there is no permission to access to that directory).
 
-2. Download this repo with Code -> Download ZIP
+2. Download this repo from Github by clicking Code button on top -> Download ZIP
 3. Install add-on normally as described here: https://docs.blender.org/manual/en/latest/editors/preferences/addons.html
 
 ## How to import .bim files

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# dotbim-blender (Version 1.2)
+# dotbim-blender (Version 1.3)
 
 ## Description
 
 It is an add-on for Blender to import and export .bim files. Check out dotbim.net or main repo for dotbim (https://github.com/paireks/dotbim) to read more about .bim files :)
 
-Script was created for Blender 2.91.
+Blender version > 3.6 is required.
 
 ## How to run a script
 

--- a/__init__.py
+++ b/__init__.py
@@ -71,7 +71,7 @@ class DOTBIM_OT_export(bpy.types.Operator, ExportHelper):
             ("SELECTED", "Selected", "Export all selected objects"),
             ("SCENE", "Scene", "Export all objects in the current scene"),
         ),
-        default="SELECTED",
+        default="SCENE",
     )
 
     author: bpy.props.StringProperty(name="Author", description="Author Name")

--- a/__init__.py
+++ b/__init__.py
@@ -40,7 +40,7 @@ class DOTBIM_OT_import(bpy.types.Operator, ImportHelper):
     def switch_to_object_color(self, context):
         for area in context.screen.areas:
             if area.type == "VIEW_3D":
-                area.spaces.active.shading.color_type = "OBJECT"
+                area.spaces.active.shading.color_type = "VERTEX"
 
     def execute(self, context):
         folder = Path(self.filepath)

--- a/__init__.py
+++ b/__init__.py
@@ -32,6 +32,16 @@ class DOTBIM_OT_import(bpy.types.Operator, ImportHelper):
         type=bpy.types.OperatorFileListElement,
         options={"HIDDEN", "SKIP_SAVE"},
     )
+    should_switch_to_object_color: bpy.props.BoolProperty(
+        name="Switch Viewport to Object Color",
+        description="Check this to switch the 3D viewport display to Object Color",
+        default=True,
+    )
+
+    def switch_to_object_color(self, context):
+        for area in context.screen.areas:
+            if area.type == "VIEW_3D":
+                area.spaces.active.shading.color_type = "OBJECT"
 
     def execute(self, context):
         folder = Path(self.filepath)
@@ -39,6 +49,8 @@ class DOTBIM_OT_import(bpy.types.Operator, ImportHelper):
             folder = folder.parent
         for file in self.files:
             dotbim_to_blender.import_from_file(f"{folder / file.name}")
+        if self.should_switch_to_object_color:
+            self.switch_to_object_color(context)
         return {"FINISHED"}
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import os.path
 import bpy
 from bpy_extras.io_utils import ImportHelper, ExportHelper
 from . import dotbim_to_blender
@@ -45,7 +44,7 @@ class DOTBIM_OT_import(bpy.types.Operator, ImportHelper):
 
     def execute(self, context):
         folder = Path(self.filepath)
-        if not os.path.isdir(folder):
+        if not folder.is_dir():
             folder = folder.parent
         for file in self.files:
             dotbim_to_blender.import_from_file(f"{folder / file.name}")

--- a/__init__.py
+++ b/__init__.py
@@ -8,8 +8,8 @@ from . import blender_to_dotbim
 bl_info = {
     "name": "dotbim",
     "author": "paireks, Gorgious56",
-    "version": (1, 2),
-    "blender": (2, 90, 0),
+    "version": (1, 3),
+    "blender": (3, 6, 0),
     "location": "",
     "description": "Exporter / Importer for lightweight dotbim format",
     "warning": "",

--- a/dotbim_to_blender.py
+++ b/dotbim_to_blender.py
@@ -34,9 +34,6 @@ def transfer_face_colors(obj, elt):
                     face_colors[i + 2],
                     face_colors[i + 3],
                 )
-
-        new_attr = obj.data.attributes.new("face_colors", "FLOAT_COLOR", "FACE")
-        new_attr.data.foreach_set("color", face_colors)
     else:
         print("Face Colors are not (yet) supported for Version < 3.6.0")
 

--- a/dotbim_to_blender.py
+++ b/dotbim_to_blender.py
@@ -22,9 +22,7 @@ def convert_dotbim_mesh_to_blender(dotbim_mesh, mesh_id):
 
 def transfer_face_colors(obj, elt):
     if bpy.app.version >= (3, 6, 0):
-        old_data = obj.data
         obj.data = obj.data.copy()  # Blender meshes don't support separate sets of attributes
-        obj.data["dotbim_mesh"] = old_data  # So we can roundtrip the mesh id and it doesn't get GCed
         face_colors = [c / 255.0 for c in elt.face_colors]
         new_attr = obj.data.color_attributes.new("face_colors", "FLOAT_COLOR", "CORNER")
         for i in range(0, len(face_colors) - 1, 4):

--- a/dotbim_to_blender.py
+++ b/dotbim_to_blender.py
@@ -20,6 +20,29 @@ def convert_dotbim_mesh_to_blender(dotbim_mesh, mesh_id):
     return mesh
 
 
+def transfer_face_colors(obj, elt):
+    if bpy.app.version >= (3, 6, 0):
+        old_data = obj.data
+        obj.data = obj.data.copy()  # Blender meshes don't support separate sets of attributes
+        obj.data["dotbim_mesh"] = old_data  # So we can roundtrip the mesh id and it doesn't get GCed
+        face_colors = [c / 255.0 for c in elt.face_colors]
+        new_attr = obj.data.color_attributes.new("face_colors", "FLOAT_COLOR", "CORNER")
+        for i in range(0, len(face_colors) - 1, 4):
+            polygon = obj.data.polygons[i // 4]
+            for corner_idx in polygon.loop_indices:
+                new_attr.data[corner_idx].color = (
+                    face_colors[i],
+                    face_colors[i + 1],
+                    face_colors[i + 2],
+                    face_colors[i + 3],
+                )
+
+        new_attr = obj.data.attributes.new("face_colors", "FLOAT_COLOR", "FACE")
+        new_attr.data.foreach_set("color", face_colors)
+    else:
+        print("Face Colors are not (yet) supported for Version < 3.6.0")
+
+
 def import_from_file(filepath):
     scene = bpy.context.scene
     file = File.read(filepath)
@@ -39,6 +62,9 @@ def import_from_file(filepath):
                 obj[item[0][0:62]] = item[1]
             obj.color = [elt.color.r / 255.0, elt.color.g / 255.0, elt.color.b / 255.0, elt.color.a / 255.0]
             scene.collection.objects.link(obj)
+
+            if hasattr(elt, "face_colors"):
+                transfer_face_colors(obj, elt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
At long last !

![image](https://github.com/paireks/dotbim-blender/assets/25156105/a265d123-ba55-465a-bdd2-0feb30aab0c3)
![image](https://github.com/paireks/dotbim-blender/assets/25156105/c1205686-72b0-4568-b6a8-af982005fc4a)

So it should work now with a few caveats :
Contrary to dotbim, Blender doesn't support linked meshes with different color attributes (=dotbim face colors) so it is impossible to have linked meshes and support face colors in the way dotbim does. 

Importing in Blender will then remove the link between linked meshes in dotbim
Similary, exporting linked meshes from Blender which have color attributes will export them as separate instances, so the mesh will be duplicated, bloating the dotbim file size.

In the future if this poses a problem I'm sur there is a way to prevent that but it would be much longer than the few dozens line of code of this PR.

Also :
- Switch to "Attribute" view mode to prevent #8
- Face colors are only supported for Blender V3.6+. It's possible to support previous version but #TODO :)
- Note blender face color attributes only support "Face corners" domain so the data is duplicated on import, and merged on export. It also means that only the color of the first corner of each polygon is taken into account on export (Blender supports multiple colors per face in each corner when dotbim supports only one).

Let me know if you have anything to add.

Cheers !